### PR TITLE
Safer way to set TCLLIBPATH

### DIFF
--- a/l/linuxcnc/PKGBUILD
+++ b/l/linuxcnc/PKGBUILD
@@ -25,7 +25,7 @@ sha256sums=('061d78ad404492fe80fbc013dfd3138c9a31d0c8e38e0a4e4eaa36d40efce816'
 
 prepare() {
   cd "${srcdir}/${pkgname}-${pkgver}/src"
-  echo "export TCLLIBPATH="$TCLLIBPATH  /usr/lib/tcltk/linuxcnc"" > ${pkgname}.sh
+  echo "export TCLLIBPATH="/usr/lib/tcltk/linuxcnc:$TCLLIBPATH"" > ${pkgname}.sh
   find . -iname fixpaths.py -o -iname checkglade -o \
    -iname update_ini | xargs perl -p -i -e "s/python/python2/"
   patch -Np2 -i $srcdir/libtirpc.patch

--- a/l/linuxcnc/PKGBUILD
+++ b/l/linuxcnc/PKGBUILD
@@ -25,7 +25,7 @@ sha256sums=('061d78ad404492fe80fbc013dfd3138c9a31d0c8e38e0a4e4eaa36d40efce816'
 
 prepare() {
   cd "${srcdir}/${pkgname}-${pkgver}/src"
-  echo "export TCLLIBPATH="/usr/lib/tcltk/linuxcnc:$TCLLIBPATH"" > ${pkgname}.sh
+  echo "[[ ":$TCLLIBPATH:" != *":/usr/lib/tcltk/linuxcnc:"* ]] && export TCLLIBPATH="/usr/lib/tcltk/linuxcnc:$TCLLIBPATH"" > ${pkgname}.sh
   find . -iname fixpaths.py -o -iname checkglade -o \
    -iname update_ini | xargs perl -p -i -e "s/python/python2/"
   patch -Np2 -i $srcdir/libtirpc.patch

--- a/l/linuxcnc/PKGBUILD
+++ b/l/linuxcnc/PKGBUILD
@@ -25,7 +25,7 @@ sha256sums=('061d78ad404492fe80fbc013dfd3138c9a31d0c8e38e0a4e4eaa36d40efce816'
 
 prepare() {
   cd "${srcdir}/${pkgname}-${pkgver}/src"
-  echo "[[ ":$TCLLIBPATH:" != *":/usr/lib/tcltk/linuxcnc:"* ]] && export TCLLIBPATH="/usr/lib/tcltk/linuxcnc:$TCLLIBPATH"" > ${pkgname}.sh
+  echo "[[ ":\$TCLLIBPATH:" != *":/usr/lib/tcltk/linuxcnc:"* ]] && export TCLLIBPATH="/usr/lib/tcltk/linuxcnc:\$TCLLIBPATH"" > ${pkgname}.sh
   find . -iname fixpaths.py -o -iname checkglade -o \
    -iname update_ini | xargs perl -p -i -e "s/python/python2/"
   patch -Np2 -i $srcdir/libtirpc.patch


### PR DESCRIPTION
In the case the environment variable is empty this will still work.