### PR TITLE
qt5-webkit do apply ruby3.2 patch

### DIFF
--- a/q/qt5-webkit/PKGBUILD
+++ b/q/qt5-webkit/PKGBUILD
@@ -51,6 +51,7 @@ prepare() {
   patch -p1 -i ../qtwebkit-cstdint.patch # gcc 11.1
   patch -p1 -i ../qtwebkit-fix-build-gcc14.patch # GCC 14.1
   patch -p1 -i ../qt5-webkit-icu75.patch
+  patch -Np1 -i ../qtwebkit-ruby3.2.patch
 }
 
 build() {


### PR DESCRIPTION
The patch file is pulled from the repo but was not actually applied