### PR TITLE
zsync2-git: Workaround incompatible-pointer-types compile errors

### DIFF
--- a/z/zsync2-git/PKGBUILD
+++ b/z/zsync2-git/PKGBUILD
@@ -16,6 +16,8 @@ conflicts=(zsync2)
 source=("git+https://github.com/AppImageCommunity/zsync2.git")
 b2sums=('SKIP')
 
+CFLAGS="$CFLAGS -Wno-incompatible-pointer-types"
+
 pkgver() {
   cd zsync2
   git describe --long --tags --exclude continuous | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g'


### PR DESCRIPTION
Workaround for these compilation errors in `zsync2-git`:

```console
/home/exampleusr/src/pub/pkgbuild/appimagelauncherd-fixes/PKGBUILD-AUR_fix/z/zsync2-git/src/zsync2/lib/libzsync/zsync.c: In function ‘zsync_get_urls’:
/home/exampleusr/src/pub/pkgbuild/appimagelauncherd-fixes/PKGBUILD-AUR_fix/z/zsync2-git/src/zsync2/lib/libzsync/zsync.c:460:18: error: returning ‘char **’ from a function with incompatible return type ‘const char * const*’ [-Wincompatible-pointer-types]
  460 |         return zs->zurl;
      |                ~~^~~~~~
/home/exampleusr/src/pub/pkgbuild/appimagelauncherd-fixes/PKGBUILD-AUR_fix/z/zsync2-git/src/zsync2/lib/libzsync/zsync.c:465:18: error: returning ‘char **’ from a function with incompatible return type ‘const char * const*’ [-Wincompatible-pointer-types]
  465 |         return zs->url;
      |                ~~^~~~~
/home/exampleusr/src/pub/pkgbuild/appimagelauncherd-fixes/PKGBUILD-AUR_fix/z/zsync2-git/src/zsync2/lib/libzsync/zsync.c: In function ‘zsync_receive_data_compressed’:
/home/exampleusr/src/pub/pkgbuild/appimagelauncherd-fixes/PKGBUILD-AUR_fix/z/zsync2-git/src/zsync2/lib/libzsync/zsync.c:945:22: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  945 |     zr->strm.next_in = buf;
      |                      ^
/home/exampleusr/src/pub/pkgbuild/appimagelauncherd-fixes/PKGBUILD-AUR_fix/z/zsync2-git/src/zsync2/lib/libzsync/zsync.c:950:43: error: passing argument 4 of ‘zsync_configure_zstream_for_zdata’ from incompatible pointer type [-Wincompatible-pointer-types]
  950 |                                           &(zr->outoffset));
      |                                           ^~~~~~~~~~~~~~~~
      |                                           |
      |                                           off_t * {aka long int *}
/home/exampleusr/src/pub/pkgbuild/appimagelauncherd-fixes/PKGBUILD-AUR_fix/z/zsync2-git/src/zsync2/lib/libzsync/zsync.c:791:65: note: expected ‘long long int *’ but argument is of type ‘off_t *’ {aka ‘long int *’}
  791 |                                        long zoffset, long long *poutoffset) {
      |                                                      ~~~~~~~~~~~^~~~~~~~~~
/home/exampleusr/src/pub/pkgbuild/appimagelauncherd-fixes/PKGBUILD-AUR_fix/z/zsync2-git/src/zsync2/lib/libzsync/zsync.c:962:26: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  962 |         zr->strm.next_in = buf;
      |                          ^
make[2]: *** [lib/libzsync/CMakeFiles/libzsync.dir/build.make:76: lib/libzsync/CMakeFiles/libzsync.dir/zsync.c.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:1034: lib/libzsync/CMakeFiles/libzsync.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
==> ERROR: A failure occurred in build().
    Aborting...
```