### PR TITLE
[heroic-games-launcher] remove unnecessary dependencies, other small changes

### DIFF
--- a/h/heroic-games-launcher/PKGBUILD
+++ b/h/heroic-games-launcher/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=heroic-games-launcher
 pkgver=2.15.2
-pkgrel=5
+pkgrel=6
 pkgdesc="Native GOG, Epic Games and Amazon games launcher for Linux"
 arch=(x86_64)
 url="https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher"

--- a/h/heroic-games-launcher/PKGBUILD
+++ b/h/heroic-games-launcher/PKGBUILD
@@ -1,14 +1,16 @@
 # Maintainer: Fabio 'Lolix' Loli <fabio.loli@disroot.org> -> https://github.com/FabioLolix
+# Contributor tippfehlr
+# Contributor chrrybmb
 
 pkgname=heroic-games-launcher
 pkgver=2.15.2
 pkgrel=2
 pkgdesc="Native GOG, Epic Games and Amazon games launcher for Linux"
 arch=(x86_64)
-url="https://heroicgameslauncher.com/"
+url="https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher"
 license=(GPL-3.0-only)
 _electron=electron31
-depends=(alsa-lib gtk3 nss which $_electron)
+depends=(which $_electron)
 makedepends=(git pnpm npm python)
 source=("git+https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher.git#tag=v${pkgver}")
 sha256sums=('b752b2c11f7d20f068b40d8122a5d4b2b9dcdf3be134d84c9888fe71559045fe')


### PR DESCRIPTION
`alsa-lib`, `gtk3`, and `nss` are not necessary dependencies since `electron31` already depends on them.

Following up on your [comment](https://github.com/FabioLolix/PKGBUILD-AUR_fix/pull/46#issuecomment-2380637987) left in tippfehlr's pr, could you please try to build this again? It builds fine for me, but if you still cannot get it to build, I may have a fix for it. Thank you for your work on maintaining this package.