### PR TITLE
Fix #24: Use xxd in makedepends (fixes conflict w/tinyxxd & vim)

### DIFF
--- a/a/appimagelauncher-git/PKGBUILD
+++ b/a/appimagelauncher-git/PKGBUILD
@@ -14,7 +14,7 @@ depends=(qt5-base qt5-declarative fuse2
          # namcap implicit depends
          glibc gcc-libs glib2 zstd cairo librsvg xz libarchive zlib
          )
-makedepends=(git cmake boost qt5-tools libxpm lib32-glibc lib32-gcc-libs tinyxxd patchelf argagg nlohmann-json)
+makedepends=(git cmake boost qt5-tools libxpm lib32-glibc lib32-gcc-libs xxd patchelf argagg nlohmann-json)
 provides=(appimagelauncher)
 conflicts=(appimagelauncher)
 source=("git+https://github.com/TheAssassin/AppImageLauncher.git"


### PR DESCRIPTION
Note: Both `tinyxxd` and `vim` have: `Provides: xxd`