### PR TITLE
Fix Clementine build

### DIFF
--- a/c/clementine-git/PKGBUILD
+++ b/c/clementine-git/PKGBUILD
@@ -43,6 +43,7 @@ pkgver() {
 
 prepare() {
   sed -i 's/cmake_policy(SET CMP0053 OLD)/cmake_policy(SET CMP0026 NEW)/' Clementine/CMakeLists.txt
+  patch Clementine/src/CMakeLists.txt ../patch/rmflags.patch
 }
 
 build() {

--- a/c/clementine-git/patch/rmflags.patch
+++ b/c/clementine-git/patch/rmflags.patch
@@ -1,0 +1,13 @@
+diff --git src/CMakeLists.txt src/CMakeLists.txt
+index d3e105f48..a71011f1d 100644
+--- src/CMakeLists.txt
++++ src/CMakeLists.txt
+@@ -7,8 +7,6 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-private-field -Wno-unknown-warning-option")
+ endif()
+ 
+-option(BUILD_WERROR "Build with -Werror" ON)
+-
+ if(BUILD_WERROR)
+   if (LINUX)
+     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")

--- a/c/clementine/PKGBUILD
+++ b/c/clementine/PKGBUILD
@@ -37,6 +37,7 @@ pkgver() {
 
 prepare() {
   sed -i 's/cmake_policy(SET CMP0053 OLD)/cmake_policy(SET CMP0026 NEW)/' Clementine/CMakeLists.txt
+  patch Clementine/src/CMakeLists.txt ../patch/rmflags.patch
 }
 
 build() {

--- a/c/clementine/patch/rmflags.patch
+++ b/c/clementine/patch/rmflags.patch
@@ -1,0 +1,13 @@
+diff --git src/CMakeLists.txt src/CMakeLists.txt
+index d3e105f48..a71011f1d 100644
+--- src/CMakeLists.txt
++++ src/CMakeLists.txt
+@@ -7,8 +7,6 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-private-field -Wno-unknown-warning-option")
+ endif()
+ 
+-option(BUILD_WERROR "Build with -Werror" ON)
+-
+ if(BUILD_WERROR)
+   if (LINUX)
+     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")


### PR DESCRIPTION
Iclusions chain contains /usr/include/absl/hash/internal/hash.h header (abseil-cpp package) includes ciso646 library deprecated in C++  
Due to -Werror flag deprecation warning will fail build