### PR TITLE
Update hgl

### DIFF
--- a/h/heroic-games-launcher/PKGBUILD
+++ b/h/heroic-games-launcher/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Fabio 'Lolix' Loli <fabio.loli@disroot.org> -> https://github.com/FabioLolix
 
 pkgname=heroic-games-launcher
-pkgver=2.18.0
+pkgver=2.18.1
 pkgrel=1
 pkgdesc="Native GOG, Epic Games and Amazon games launcher for Linux"
 arch=(x86_64)
@@ -13,7 +13,7 @@ makedepends=(git pnpm npm python desktop-file-utils
 			 nodejs-lts-jod
 			 )
 source=("git+https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher.git#tag=v${pkgver}")
-sha256sums=('ec0a6ffd80eca1c8c5c41752ec2f7d4c004eb03b12221ede67d9928b3e244107')
+sha256sums=('85e842109249b7f830dba57a76ff04f7bab92179874c7daabb7d660f25843f9f')
 
 build() {
   cd HeroicGamesLauncher


### PR DESCRIPTION
Update hgl to 2.18.1.

Also, `heroic-games-launcher` has been out of date on the AUR since 2025-07-23. I did see that you did update it here, but I am confused as to why you did not push the change to the AUR? Anyways, thank you.