### PR TITLE
Add CMAKE_POLICY_VERSION_MINIMUM to build AIL v3

### DIFF
--- a/a/appimagelauncher-git/PKGBUILD
+++ b/a/appimagelauncher-git/PKGBUILD
@@ -3,8 +3,8 @@
 # Contributor: TheAssassin
 
 pkgname=appimagelauncher-git
-pkgver=r1329.3d42d4c
-pkgrel=2
+pkgver=r1334.8f80428
+pkgrel=1
 pkgdesc="A Helper application for running and integrating AppImages."
 arch=(x86_64)
 url="https://github.com/TheAssassin/AppImageLauncher"
@@ -33,7 +33,8 @@ build() {
   # Disable all warnings
   export CFLAGS+=" -w"
   export CXXFLAGS+=" -w"
-
+  export CMAKE_POLICY_VERSION_MINIMUM=3.5
+  
   local _flags=(
     -DBUILD_TESTING=OFF
     -DFETCHCONTENT_QUIET=OFF


### PR DESCRIPTION
Current build is broken with latest CMAKE versions. Adding `CMAKE_POLICY_VERSION_MINIMUM` seems to help here.

Build now succeds:

```
$ makepkg -fsi
...

$ ./pkg/appimagelauncher-git/usr/bin/ail-cli --version
ail-cli version 3.0.0-alpha-4 (git commit 8f80428), built on 2025-08-21 22:01:02 UTC
```