### PR TITLE
quickemu-git: add pandoc as make dependency

### DIFF
--- a/q/quickemu-git/PKGBUILD
+++ b/q/quickemu-git/PKGBUILD
@@ -32,7 +32,7 @@ depends=(qemu-desktop
          xorg-xrandr # xrandr
          zsync
          unzip)
-makedepends=(git)
+makedepends=(git pandoc)
 optdepends=('quickgui: graphical user interface')
 provides=(quickemu)
 conflicts=(quickemu)


### PR DESCRIPTION
The package depends on pandoc to be built but it is not declared as makedepends. This causes:

```
  ==> Starting package()...
  install -d /home/fho/git/PKGBUILD-AUR_fix/q/quickemu-git/pkg/quickemu-git/usr/bin
  install -m 755 ../quickget /home/fho/git/PKGBUILD-AUR_fix/q/quickemu-git/pkg/quickemu-git/usr/bin
  install -m 755 ../quickemu /home/fho/git/PKGBUILD-AUR_fix/q/quickemu-git/pkg/quickemu-git/usr/bin
  install -m 755 ../quickreport /home/fho/git/PKGBUILD-AUR_fix/q/quickemu-git/pkg/quickemu-git/usr/bin
  install -m 755 ../chunkcheck /home/fho/git/PKGBUILD-AUR_fix/q/quickemu-git/pkg/quickemu-git/usr/bin
  pandoc --standalone -f gfm+definition_lists --to man -o quickemu.1 quickemu.1.md
  make: pandoc: No such file or directory
  make: *** [pandoc-man.mk:7: quickemu.1] Error 127
  ==> ERROR: A failure occurred in package().
      Aborting...
```

The package runs "make install" of docs/Makefile[^1]. Target dependencies:
install -> install_docs -> quickget.1 quickemu.1 quickemu_conf.5 -> .1.md.1 .5.md.5[^2]

Fix it by adding pandoc as makedep.

Fixes: https://aur.archlinux.org/packages/quickemu-git#comment-1040920

[^1]: https://github.com/quickemu-project/quickemu/blob/master/docs/Makefile
[^2]: https://github.com/quickemu-project/quickemu/blob/master/docs/pandoc-man.mk