### PR TITLE
Update nomacs

### DIFF
--- a/n/nomacs/PKGBUILD
+++ b/n/nomacs/PKGBUILD
@@ -4,40 +4,27 @@
 
 _plugins_ver=3.16
 pkgname=nomacs
-pkgver=3.21.0
-pkgrel=2
+pkgver=3.22.0
+pkgrel=1
 epoch=1
 pkgdesc="A Qt image viewer"
 arch=(x86_64)
 url="https://github.com/nomacs/nomacs"
 license=(GPL-3.0-only)
-depends=(exiv2 gcc-libs glibc libraw libtiff opencv qt6-base qt6-svg quazip-qt6)
-#depends+=(libopencv_imgproc.so)
-makedepends=(cmake git git-lfs qt6-tools python)
+depends=(exiv2 hicolor-icon-theme gcc-libs glibc libglvnd libraw libtiff opencv qt6-base qt6-svg quazip-qt6)
+makedepends=(cmake qt6-tools python)
 optdepends=('qt6-imageformats: support additional image formats'
             'kimageformats: support QOI (Quite OK Image Format)')
-source=("git+https://github.com/nomacs/nomacs.git#tag=${pkgver}"
-        #"nomacs-plugins-qt6_01.patch::https://github.com/nomacs/nomacs-plugins/pull/40/commits/1b87f615ce0e7125ec739bc3e40d8ff7f6783587.patch"
-        #"nomacs-plugins-qt6_02.patch::https://github.com/nomacs/nomacs-plugins/pull/40/commits/a869962f051504dd2c1dedeb3bc3d266c17070c1.patch"
-        #"nomacs-plugins-${_plugins_ver}.tar.gz::https://github.com/nomacs/nomacs-plugins/archive/${_plugins_ver}.tar.gz"
-        )
-b2sums=('3360bfeab0c1d323903240b136c2d9baf58f49cf0d672d69bc1473fbb0fe00103885f7d0194ee2200259cb548ad8c6d77127c96486f82055493cc89488bd9f99')
-
-export GIT_LFS_SKIP_SMUDGE=1
+source=("$url/archive/refs/tags/${pkgver}.tar.gz")
+b2sums=('b99c098a5b0a2f3da53bc19f9dbddbebbca983bdd7e4b83bdcb4e141fed0cf74a8af11341a202a81c8964a3577901a61795214ae5f36ab4d83e21b73bb2dece6')
 
 prepare() {
-  #cd "nomacs-plugins-${_plugins_ver}"
-  #patch -Np1 -i ../nomacs-plugins-qt6_01.patch
-  #patch -Np1 -i ../nomacs-plugins-qt6_02.patch
-
-  cd "${srcdir}/nomacs"
-  # copy plugin sources into place
-  #cp -av "${srcdir}/nomacs-plugins-${_plugins_ver}/"* "ImageLounge/plugins"
+  cd "${srcdir}/nomacs-${pkgver}"
 }
 
 build() {
-  cd nomacs
-  cmake -B build -S ImageLounge -Wno-dev \
+  cd "${srcdir}"
+  cmake -B build -S nomacs-${pkgver}/ImageLounge -Wno-dev \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DCMAKE_INSTALL_PREFIX=/usr \
     -DQT_VERSION_MAJOR=6 \
@@ -50,6 +37,6 @@ build() {
 }
 
 package() {
-  cd nomacs
+  cd "${srcdir}"
   DESTDIR="$pkgdir" cmake --install build
 }


### PR DESCRIPTION
This pull request does the following:

1. Updates `nomacs` to 3.22.0
2. Adds `hicolor-icon-theme` and `libglvnd` to `depends()`. From `namcap`.
3. Switches from git sources to tarball. This saves on how much the user needs to download, and removes the `git` and `git-lfs` dependency.
4. Remove items from `source()` that are no longer needed. Saves on amount of data downloaded for the user. 
5. Put the `build` directory at `"$srcdir/build"` instead of `"$srcdir/nomacs-${pkgver}/build"`. This is how the CMake packaging guidelines recommend it.